### PR TITLE
feature/hostname: add hostname to ELKMessage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { git = "https://github.com/tokio-rs/tracing" }
 tracing-core = { git = "https://github.com/tokio-rs/tracing" }
 tracing-subscriber = { git = "https://github.com/tokio-rs/tracing" }
 chrono = "0.4"
+lazy_static = "1.4"
 
 [[example]]
 name = "syslog"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,15 @@ pub use message::{ELKMessage, SyslogMessage};
 pub use syslog::*;
 pub use subscriber::{Subscriber, SubscriberBuilder};
 pub use backend::LoggerBackendBuilder;
+
+#[macro_use]
+extern crate lazy_static;
+
+lazy_static! {
+    static ref HOSTNAME: String = {
+        match std::env::var("HOSTNAME") {
+            Ok(value) => value,
+            Err(_) => "undefined".to_string(),
+        }
+    };
+}

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,13 +1,4 @@
-use lazy_static::lazy_static;
-
-lazy_static! {
-    static ref HOSTNAME: String = {
-        match std::env::var("HOSTNAME") {
-            Ok(value) => value,
-            Err(_) => "undefined".to_string(),
-        }
-    };
-}
+use crate::HOSTNAME;
 
 pub trait SyslogMessage {
     fn message(&self, pairs: Vec<(String, String)>) -> String;


### PR DESCRIPTION
A section in [RFC3146](https://tools.ietf.org/html/rfc3164#section-4.1.2) about header says that the header part consists of two parts - a timestamp and hostname or IP address of the device. In the current ELKMessage hostname is hardcoded.